### PR TITLE
Dev fork joel

### DIFF
--- a/scale_pyramid.py
+++ b/scale_pyramid.py
@@ -141,7 +141,7 @@ def create_scale_pyramid(in_file, in_ds_name, scales, chunk_shape, compressor={'
             voxel_size=next_voxel_size,
             write_size=next_write_size,
             dtype=prev_array.dtype,
-            num_channels=num_channels
+            num_channels=num_channels,
             compressor=compressor)
 
         downscale(prev_array, next_array, scale, next_write_size)
@@ -178,13 +178,6 @@ if __name__ == "__main__":
         type=int,
         default=None,
         help="The size of a chunk in voxels")
-    parser.add_argument(
-        '--compressor',
-        '-C',
-        nargs='*',
-        type=dict,
-        default={'id': 'zlib', 'level': 5},
-        help="The compressor as a dict where 'id' is compressor name and 'level' is compression level")
 
     args = parser.parse_args()
 

--- a/scale_pyramid.py
+++ b/scale_pyramid.py
@@ -75,6 +75,14 @@ def downscale(in_array, out_array, factor, write_size):
 
 def create_scale_pyramid(in_file, in_ds_name, scales, chunk_shape, compressor={'id': 'zlib', 'level': 5}):
 
+    print("\nCreating scale pyramid...")
+    print("\n  Input parameters:")
+    print("    in_file       : ", in_file)
+    print("    in_ds_name    : ", in_ds_name)
+    print("    scales        : ", str(scales))
+    print("    chunk_shape   : ", str(chunk_shape))
+    print("    compressor    : ", str(compressor))
+
     ds = zarr.open(in_file)
 
     # make sure in_ds_name points to a dataset

--- a/scale_pyramid.py
+++ b/scale_pyramid.py
@@ -53,7 +53,8 @@ def downscale(in_array, out_array, factor, write_size):
 
     print("Processing ROI %s with blocks %s" % (out_array.roi, block_roi))
 
-    daisy.run_blockwise(
+    downscale_task=daisy.Task(
+        'downscale',
         out_array.roi,
         block_roi,
         block_roi,
@@ -66,7 +67,11 @@ def downscale(in_array, out_array, factor, write_size):
         num_workers=60,
         max_retries=0,
         fit='shrink')
+    
+    done = daisy.run_blockwise([downscale_task])
 
+    if not done:
+        raise RuntimeError("daisy.Task failed for (at least) one block")
 
 def create_scale_pyramid(in_file, in_ds_name, scales, chunk_shape, compressor={'id': 'zlib', 'level': 5}):
 

--- a/scale_pyramid.py
+++ b/scale_pyramid.py
@@ -48,7 +48,7 @@ def downscale(in_array, out_array, factor, write_size):
 
     print("Downsampling by factor %s" % (factor,))
 
-    dims = in_array.roi.dims()
+    dims = in_array.roi.dims
     block_roi = daisy.Roi((0,)*dims, write_size)
 
     print("Processing ROI %s with blocks %s" % (out_array.roi, block_roi))

--- a/scale_pyramid.py
+++ b/scale_pyramid.py
@@ -102,7 +102,7 @@ def create_scale_pyramid(in_file, in_ds_name, scales, chunk_shape, compressor={'
         print("Reusing chunk shape of %s for new datasets" % (chunk_shape,))
 
     if prev_array.n_channel_dims == 0:
-        num_channels = 1
+        num_channels = None
     elif prev_array.n_channel_dims == 1:
         num_channels = prev_array.shape[0]
     else:

--- a/scale_pyramid.py
+++ b/scale_pyramid.py
@@ -76,7 +76,7 @@ def downscale(in_array, out_array, factor, write_size):
 def create_scale_pyramid(in_file, in_ds_name, scales, chunk_shape, compressor={'id': 'zlib', 'level': 5}):
 
     print("\nCreating scale pyramid...")
-    print("\n  Input parameters:")
+    print("\n  Input arguments:")
     print("    in_file       : ", in_file)
     print("    in_ds_name    : ", in_ds_name)
     print("    scales        : ", str(scales))

--- a/scale_pyramid.py
+++ b/scale_pyramid.py
@@ -68,7 +68,7 @@ def downscale(in_array, out_array, factor, write_size):
         fit='shrink')
 
 
-def create_scale_pyramid(in_file, in_ds_name, scales, chunk_shape):
+def create_scale_pyramid(in_file, in_ds_name, scales, chunk_shape, compressor={'id': 'zlib', 'level': 5}):
 
     ds = zarr.open(in_file)
 
@@ -136,7 +136,8 @@ def create_scale_pyramid(in_file, in_ds_name, scales, chunk_shape):
             voxel_size=next_voxel_size,
             write_size=next_write_size,
             dtype=prev_array.dtype,
-            num_channels=num_channels)
+            num_channels=num_channels
+            compressor=compressor)
 
         downscale(prev_array, next_array, scale, next_write_size)
 
@@ -172,6 +173,13 @@ if __name__ == "__main__":
         type=int,
         default=None,
         help="The size of a chunk in voxels")
+    parser.add_argument(
+        '--compressor',
+        '-C',
+        nargs='*',
+        type=dict,
+        default={'id': 'zlib', 'level': 5},
+        help="The compressor as a dict where 'id' is compressor name and 'level' is compression level")
 
     args = parser.parse_args()
 


### PR DESCRIPTION
Fixes for daisy v1.0 support:
* dims = in_array.roi.dims()    ->    dims = in_array.roi.dims
* num_channels = 1    ->    num_channels = None
* replace deprecated call to daisy.run_blockwise with new daisy.Task

Improvements:
* when create_scale_pyramid is called programmatically, compressor can be supplied as an argument ("cname"/"clevel") . The value it accepts is a dict where key 'id' holds a string value for compressor type; key 'level' holds an integer value for compression level.
* zlib swapped for gzip as default compressor
* print statements added to create_scale_pyramid that aid in debugging when arguments are chosen by the user from a GUI at runtime